### PR TITLE
Fix double comparison

### DIFF
--- a/src/utility/utility.h
+++ b/src/utility/utility.h
@@ -7,7 +7,7 @@ namespace RayTracer {
 constexpr double DOUBLE_EPSILON = 1e-5;
 
 inline bool is_double_eq(double a, double b) {
-  if (abs(a - b) < DOUBLE_EPSILON) {
+  if (std::fabs(a - b) < DOUBLE_EPSILON) {
     return true;
   }
 


### PR DESCRIPTION
abs is not overloaded for double for some compiler. We need to explicitly use std::fabs or at least std::abs for getting abs of double